### PR TITLE
Don't add indexes via xml to prevent purging on reinstall

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.0 Unreleased
 --------------
 
+- Moved adding catalog indexes to a setuphandler step in PAM.
+  Added testing profile to still add those indexes via Generic Setup, but
+  only for testing
+  [pysailor]
 
 1.0rc1 2013-01-26
 -----------------

--- a/src/plone/multilingual/profiles/testing/catalog.xml
+++ b/src/plone/multilingual/profiles/testing/catalog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!-- For testing, we add the necessary catalog indexes via Generic Setup.
+     For regular installation in a Plone site, the idexes are added via a
+     setuphandlers step in plone.app.multilingual -->
+<object name="portal_catalog" meta_type="Plone Catalog Tool">
+ <index name="TranslationGroup" meta_type="FieldIndex">
+  <indexed_attr value="TranslationGroup"/>
+ </index>
+ <index name="Language" meta_type="FieldIndex">
+  <indexed_attr value="Language"/>
+ </index>
+ <column value="Language"/>
+ <column value="TranslationGroup"/>
+</object>
+

--- a/src/plone/multilingual/profiles/testing/metadata.xml
+++ b/src/plone/multilingual/profiles/testing/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>03</version>
+  <dependencies>
+      <dependency>profile-plone.multilingual:default</dependency>
+  </dependencies>
+</metadata>

--- a/src/plone/multilingual/testing.py
+++ b/src/plone/multilingual/testing.py
@@ -36,14 +36,14 @@ class PloneMultilingualLayer(PloneSandboxLayer):
         import plone.multilingual
 
         # load ZCML
-        xmlconfig.file('configure.zcml', plone.multilingual,
+        xmlconfig.file('testing.zcml', plone.multilingual,
                         context=configurationContext)
         xmlconfig.file('configure.zcml', plone.multilingual.tests,
                         context=configurationContext)
 
     def setUpPloneSite(self, portal):
         # install into the Plone site
-        applyProfile(portal, 'plone.multilingual:default')
+        applyProfile(portal, 'plone.multilingual:testing')
         from zope.interface import classImplements
         from Products.ATContentTypes.content.folder import ATFolder
         classImplements(ATFolder, ITranslatable)

--- a/src/plone/multilingual/testing.zcml
+++ b/src/plone/multilingual/testing.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="plone.app.multilingual">
+
+  <include file="configure.zcml" />
+
+  <genericsetup:registerProfile
+      name="testing"
+      title="plone.multilingual tests"
+      directory="profiles/testing"
+      description="Steps to ease tests of plone.multilingual"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+</configure>


### PR DESCRIPTION
There's already a step add_catalog_indexes in plone.app.multilingual's setuphandlers, so adding the indexes here in plone.multilingual is not necessary any more. And it's quite annoying having to reindex the catalog after every re-install...
